### PR TITLE
fix: set correct color for first line segment

### DIFF
--- a/Leaflet.MultiOptionsPolyline.js
+++ b/Leaflet.MultiOptionsPolyline.js
@@ -63,7 +63,7 @@ L.MultiOptionsPolyline = L.FeatureGroup.extend({
 
             if (i === 1) {
                 segmentLatlngs = [latlngs[0]];
-                prevOptionIdx = optionIdx;
+                prevOptionIdx = optionIdxFn.call(fnContext, latlngs[0], latlngs[0], 0, latlngs);
             }
 
             segmentLatlngs.push(latlngs[i]);


### PR DESCRIPTION
color of first line part was always same as for second line part, because prevOptionIdx was not set correctly.